### PR TITLE
🚸 Fix compile  error while using OpenSSL which is version higher than…

### DIFF
--- a/common/RSACipher.hpp
+++ b/common/RSACipher.hpp
@@ -109,7 +109,7 @@ namespace nkg {
 #elif (OPENSSL_VERSION_NUMBER & 0xffff0000) == 0x10100000     // openssl 1.1.x
             return RSA_bits(Get());
 #else
-#error "Unexpected openssl version!"
+            return RSA_bits(Get());
 #endif
         }
 

--- a/common/RSACipher.hpp
+++ b/common/RSACipher.hpp
@@ -108,7 +108,7 @@ namespace nkg {
             }
 #elif (OPENSSL_VERSION_NUMBER & 0xffff0000) == 0x10100000     // openssl 1.1.x
             return RSA_bits(Get());
-#else
+#elif (OPENSSL_VERSION_NUMBER & 0xffff0000) == 0x30000000     // openssl 3.0.x
             return RSA_bits(Get());
 #endif
         }


### PR DESCRIPTION
Environment: Ubuntu-22.04
OpenSSL version: OpenSSL 3.0.2
Tigger: `cd ${repo} && make all`
Error: `./common/RSACipher.hpp:112:2: error: #error "Unexpected openssl version!"`

According to this [RSA_bits](https://www.openssl.org/docs/man3.1/man3/RSA_bits.html) document, I have aware that to use [EVP_PKEY_get_bits(3)](https://www.openssl.org/docs/man3.1/man3/EVP_PKEY_get_bits.html) instead of RSA_bits. 

Somehow since I have finished my course I have not done any C++ program. I do not even know how to solve errors from VSCode. Thus I have to change the logic due to make this repo work.

If you 'd have a beer time to read this and fix this problem, That would be grateful!  Thank you for you contribution!